### PR TITLE
`dev` branch is outdated and behind `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,8 @@ A general-purpose **Incremental Computation** (IC) library for Rust.
 Versions:
 ---------
 
-- The [Adapton repo](https://github.com/Adapton/adapton.rust) has the latest, in `dev` and `master` branches.  
-    - branch [dev](https://github.com/Adapton/adapton.rust/tree/dev) contains the **latest development**.  
-    - branch `master` is "stable", e.g., for external libraries.  
-    - Also see the [Adapton crate](https://crates.io/crates/adapton) for periodic "stable" releases.  
+- The [Adapton repo](https://github.com/Adapton/adapton.rust) has the latest code version in the `master` branch.  
+- The [Adapton crate](https://crates.io/crates/adapton) for periodic "stable" releases.  
 - See also: A prior [OCaml implementation](https://github.com/plum-umd/adapton.ocaml).  
 
 Research and Development Community:


### PR DESCRIPTION
So removing the mention from the README